### PR TITLE
Secondary daughterboard ID fixes

### DIFF
--- a/kernel_driver/la9310rfnm/rfnm_breakout_m.c
+++ b/kernel_driver/la9310rfnm/rfnm_breakout_m.c
@@ -120,22 +120,30 @@ static int rfnm_breakout_probe(struct spi_device *spi)
 	struct rfnm_api_tx_ch *tx_ch, *tx_s;
 	struct rfnm_api_rx_ch *rx_ch[2], *rx_s[2];
 
-	tx_ch = devm_kzalloc(dev, sizeof(struct rfnm_api_tx_ch), GFP_KERNEL);
+	if (dgb_id == 0) {
+		tx_ch = devm_kzalloc(dev, sizeof(struct rfnm_api_tx_ch), GFP_KERNEL);
+		tx_s = devm_kzalloc(dev, sizeof(struct rfnm_api_tx_ch), GFP_KERNEL);
+		if (!tx_ch || !tx_s) {
+			return -ENOMEM;
+		}
+	}
+
 	rx_ch[0] = devm_kzalloc(dev, sizeof(struct rfnm_api_rx_ch), GFP_KERNEL);
 	rx_ch[1] = devm_kzalloc(dev, sizeof(struct rfnm_api_rx_ch), GFP_KERNEL);
-	tx_s = devm_kzalloc(dev, sizeof(struct rfnm_api_tx_ch), GFP_KERNEL);
 	rx_s[0] = devm_kzalloc(dev, sizeof(struct rfnm_api_rx_ch), GFP_KERNEL);
 	rx_s[1] = devm_kzalloc(dev, sizeof(struct rfnm_api_rx_ch), GFP_KERNEL);
 	
-	if(!tx_ch || !rx_ch[0] || !rx_ch[1] || !tx_s || !rx_s[0] || !rx_s[1]) {
+	if(!(rx_ch[0] && rx_ch[1] && rx_s[0] && rx_s[1])) {
 		return -ENOMEM;
 	}
 
-	tx_ch->freq_max = MHZ_TO_HZ(6300);
-	tx_ch->freq_min = MHZ_TO_HZ(0);
-	tx_ch->path_preferred = RFNM_PATH_SMA_B;
-	tx_ch->dac_id = 0;
-	rfnm_dgb_reg_tx_ch(dgb_dt, tx_ch, tx_s);
+	if (dgb_id == 0) {
+		tx_ch->freq_max = MHZ_TO_HZ(6300);
+		tx_ch->freq_min = MHZ_TO_HZ(0);
+		tx_ch->path_preferred = RFNM_PATH_SMA_B;
+		tx_ch->dac_id = 0;
+		rfnm_dgb_reg_tx_ch(dgb_dt, tx_ch, tx_s);
+	}
 
 	rx_ch[0]->freq_max = MHZ_TO_HZ(6300);
 	rx_ch[0]->freq_min = MHZ_TO_HZ(0);

--- a/kernel_driver/la9310rfnm/rfnm_daughterboard.c
+++ b/kernel_driver/la9310rfnm/rfnm_daughterboard.c
@@ -62,6 +62,7 @@ void rfnm_dgb_reg_rx_ch(struct rfnm_dgb *dgb_dt, struct rfnm_api_rx_ch * rx_ch, 
 	rx_ch->dgb_id = dgb_slot;
 	rx_ch->dgb_ch_id = rfnm_dgb[dgb_slot]->rx_ch_cnt;
 	rx_ch->abs_id = abs_ch_cnt_rx++;
+	rx_ch->adc_id += dgb_slot * 2;
 	rfnm_dgb[dgb_slot]->rx_ch[rx_ch->dgb_ch_id] = rx_ch;
 	rfnm_dgb[dgb_slot]->rx_s[rx_ch->dgb_ch_id] = rx_s;
 	rfnm_dgb[dgb_slot]->rx_ch_cnt++;

--- a/kernel_driver/la9310rfnm/rfnm_daughterboard.c
+++ b/kernel_driver/la9310rfnm/rfnm_daughterboard.c
@@ -79,6 +79,9 @@ EXPORT_SYMBOL(rfnm_dgb_reg_rx_ch);
 
 void rfnm_dgb_reg_tx_ch(struct rfnm_dgb *dgb_dt, struct rfnm_api_tx_ch * tx_ch, struct rfnm_api_tx_ch * tx_s) { 
 	int dgb_slot = dgb_dt->dgb_id;
+	if (dgb_slot != 0) {
+		return;
+	}
 	rfnm_dgb[dgb_slot] = dgb_dt;
 	tx_ch->dgb_id = dgb_slot;
 	tx_ch->dgb_ch_id = rfnm_dgb[dgb_slot]->tx_ch_cnt;

--- a/kernel_driver/la9310rfnm/rfnm_granita_m.c
+++ b/kernel_driver/la9310rfnm/rfnm_granita_m.c
@@ -677,28 +677,35 @@ static int rfnm_granita_probe(struct spi_device *spi)
 	struct rfnm_api_tx_ch *tx_ch, *tx_s;
 	struct rfnm_api_rx_ch *rx_ch[2], *rx_s[2];
 
-	tx_ch = devm_kzalloc(dev, sizeof(struct rfnm_api_tx_ch), GFP_KERNEL);
+	if (dgb_id == 0) {
+		tx_ch = devm_kzalloc(dev, sizeof(struct rfnm_api_tx_ch), GFP_KERNEL);
+		tx_s = devm_kzalloc(dev, sizeof(struct rfnm_api_tx_ch), GFP_KERNEL);
+		if (!tx_ch || !tx_s) {
+			return -ENOMEM;
+		}
+	}
 	rx_ch[0] = devm_kzalloc(dev, sizeof(struct rfnm_api_rx_ch), GFP_KERNEL);
 	rx_ch[1] = devm_kzalloc(dev, sizeof(struct rfnm_api_rx_ch), GFP_KERNEL);
-	tx_s = devm_kzalloc(dev, sizeof(struct rfnm_api_tx_ch), GFP_KERNEL);
 	rx_s[0] = devm_kzalloc(dev, sizeof(struct rfnm_api_rx_ch), GFP_KERNEL);
 	rx_s[1] = devm_kzalloc(dev, sizeof(struct rfnm_api_rx_ch), GFP_KERNEL);
 	
-	if(!tx_ch || !rx_ch[0] || !rx_ch[1] || !tx_s || !rx_s[0] || !rx_s[1]) {
+	if(!(rx_ch[0] && rx_ch[1] && rx_s[0] && rx_s[1])) {
 		return -ENOMEM;
 	}
 
-	tx_ch->freq_max = MHZ_TO_HZ(6300);
-	tx_ch->freq_min = MHZ_TO_HZ(600);
-	tx_ch->path_preferred = RFNM_PATH_SMA_B;
-	tx_ch->path_possible[0] = RFNM_PATH_SMA_B;
-	tx_ch->path_possible[1] = RFNM_PATH_SMA_A;
-	tx_ch->path_possible[2] = RFNM_PATH_NULL;
-	tx_ch->power_range.min = -60;
-	tx_ch->power_range.max = 30;
+	if (dgb_id == 0) {
+		tx_ch->freq_max = MHZ_TO_HZ(6300);
+		tx_ch->freq_min = MHZ_TO_HZ(600);
+		tx_ch->path_preferred = RFNM_PATH_SMA_B;
+		tx_ch->path_possible[0] = RFNM_PATH_SMA_B;
+		tx_ch->path_possible[1] = RFNM_PATH_SMA_A;
+		tx_ch->path_possible[2] = RFNM_PATH_NULL;
+		tx_ch->power_range.min = -60;
+		tx_ch->power_range.max = 30;
 
-	tx_ch->dac_id = 0;
-	rfnm_dgb_reg_tx_ch(dgb_dt, tx_ch, tx_s);
+		tx_ch->dac_id = 0;
+		rfnm_dgb_reg_tx_ch(dgb_dt, tx_ch, tx_s);
+	}
 
 	rx_ch[0]->freq_max = MHZ_TO_HZ(6300);
 	rx_ch[0]->freq_min = MHZ_TO_HZ(600);

--- a/kernel_driver/la9310rfnm/rfnm_lime_m.c
+++ b/kernel_driver/la9310rfnm/rfnm_lime_m.c
@@ -640,24 +640,31 @@ static int rfnm_lime_probe(struct spi_device *spi)
 	struct rfnm_api_tx_ch *tx_ch, *tx_s;
 	struct rfnm_api_rx_ch *rx_ch, *rx_s;
 
-	tx_ch = devm_kzalloc(dev, sizeof(struct rfnm_api_tx_ch), GFP_KERNEL);
+	if (dgb_id == 0) {
+		tx_ch = devm_kzalloc(dev, sizeof(struct rfnm_api_tx_ch), GFP_KERNEL);
+		tx_s = devm_kzalloc(dev, sizeof(struct rfnm_api_tx_ch), GFP_KERNEL);
+		if (!tx_ch || !tx_s) {
+			return -ENOMEM;
+		}
+	}
 	rx_ch = devm_kzalloc(dev, sizeof(struct rfnm_api_rx_ch), GFP_KERNEL);
-	tx_s = devm_kzalloc(dev, sizeof(struct rfnm_api_tx_ch), GFP_KERNEL);
 	rx_s = devm_kzalloc(dev, sizeof(struct rfnm_api_rx_ch), GFP_KERNEL);
 
-	if(!tx_ch || !rx_ch || !tx_s || !rx_s) {
+	if(!rx_ch || !rx_s) {
 		return -ENOMEM;
 	}
 
-	tx_ch->freq_max = MHZ_TO_HZ(3500);
-	tx_ch->freq_min = MHZ_TO_HZ(10);
-	tx_ch->path_preferred = RFNM_PATH_SMA_A;
-	tx_ch->path_possible[0] = RFNM_PATH_SMA_A;
-	tx_ch->path_possible[1] = RFNM_PATH_NULL;
-	tx_ch->power_range.min = -60;
-	tx_ch->power_range.max = 30;
-	tx_ch->dac_id = 0;
-	rfnm_dgb_reg_tx_ch(dgb_dt, tx_ch, tx_s);
+	if (dgb_id == 0) {
+		tx_ch->freq_max = MHZ_TO_HZ(3500);
+		tx_ch->freq_min = MHZ_TO_HZ(10);
+		tx_ch->path_preferred = RFNM_PATH_SMA_A;
+		tx_ch->path_possible[0] = RFNM_PATH_SMA_A;
+		tx_ch->path_possible[1] = RFNM_PATH_NULL;
+		tx_ch->power_range.min = -60;
+		tx_ch->power_range.max = 30;
+		tx_ch->dac_id = 0;
+		rfnm_dgb_reg_tx_ch(dgb_dt, tx_ch, tx_s);
+	}
 
 	rx_ch->freq_max = MHZ_TO_HZ(3500);
 	rx_ch->freq_min = MHZ_TO_HZ(10);


### PR DESCRIPTION
These fixes seem to get a secondary Lime daughterboard working along with https://github.com/rfnm/librfnm/pull/15 and https://github.com/rfnm/soapy-rfnm/pull/18.

I think the final commit in the series is probably unnecessary for functionality and can be dropped if you'd prefer to not mix the notion of which daughterboard slots have DACs available into the daughterboard modules. (Though I haven't tested that yet)

```
% SoapySDRUtil --args="driver=RFNM" --direction=RX --rate=61.44e6 --channels="0,1"
######################################################
##     Soapy SDR -- the SDR abstraction library     ##
######################################################

[2024-06-19 21:44:21.244] [info] rfnm_device_create()
[2024-06-19 21:44:21.244] [info] RFNMDevice::RFNMDevice()
[2024-06-19 21:44:21.255] [info] Max theoretical transport speed is 3500 Mbps
Stream format: CS16
Num channels: 2
Element size: 4 bytes
Begin RX rate test at 61.44 Msps
Starting stream loop, press Ctrl+C to exit...
[2024-06-19 21:44:21.418] [info] RFNMDevice::activateStream()
[2024-06-19 21:44:21.471] [info] cc 2 overwritten to 7 at queue size 101 adc 2
61.4453 Msps	491.562 MBps
61.4429 Msps	491.544 MBps
61.4432 Msps	491.545 MBps
61.4427 Msps	491.542 MBps
61.4344 Msps	491.475 MBps
61.4298 Msps	491.438 MBps
61.4417 Msps	491.534 MBps
61.4422 Msps	491.538 MBps
61.4417 Msps	491.533 MBps
61.4409 Msps	491.527 MBps
61.4408 Msps	491.527 MBps
61.4412 Msps	491.53 MBps
61.4408 Msps	491.527 MBps
61.4404 Msps	491.523 MBps
61.4408 Msps	491.526 MBps
61.441 Msps	491.528 MBps
```