### PR TITLE
Add functionMask parameter to allow selective disabling of MSG and NCM functions.

### DIFF
--- a/README
+++ b/README
@@ -59,11 +59,17 @@ Build Instructions
 
     export KERNEL_DIR = [path to Kernel source]
 
+    export LA9310_COMMON_HEADERS = [path to la9310-freertos/common_headers]
+
+    export RFNM_BUILD_DIR = [path to RFNM top level directory]
+
     export CROSS_COMPILE =  CROSS compiler name without 'gcc' [For exmaple aarch64-linux-gnu-] 
 
     export CROSS_COMPILE_PATH = [path to cross compiler]
 
     export PATH=$CROSS_COMPILE_PATH:$PATH  
+
+2.rfnm just run 'make' to build the driver, other targets are presently not required and disabled     
 
 2.a. make all/clean/install : To build, clean and install the whole repository. make install will
      copy all the .ko, .so/.a, app executable files to la9310_host_sw/install directory, all these

--- a/kernel_driver/la9310rfnm/Makefile
+++ b/kernel_driver/la9310rfnm/Makefile
@@ -9,7 +9,7 @@ ifeq (${DEBUG}, 1)
 ccflags-y += -g -DDEBUG
 endif
 
-RFNM_BUILD_DIR = /home/davide
+#RFNM_BUILD_DIR = /home/davide
 
 ccflags-y += -I${LA9310_DRV_HEADER_DIR} -I${LA9310_COMMON_HEADERS} 
 ccflags-y += -I${RFNM_BUILD_DIR}/la9310-driver/LimeSuiteNG/embedded/include
@@ -46,7 +46,7 @@ rfnm_lime-objs += ../../LimeSuiteNG/embedded/lms7002m/privates.o
 rfnm_breakout-objs := rfnm_breakout_m.o 
 
 # comment out to disable granita module
-obj-m += rfnm_granita.o 
+# obj-m += rfnm_granita.o 
 
 obj-m += rfnm_lime.o rfnm_breakout.o
 

--- a/kernel_driver/la9310rfnm/Makefile
+++ b/kernel_driver/la9310rfnm/Makefile
@@ -46,7 +46,7 @@ rfnm_lime-objs += ../../LimeSuiteNG/embedded/lms7002m/privates.o
 rfnm_breakout-objs := rfnm_breakout_m.o 
 
 # comment out to disable granita module
-# obj-m += rfnm_granita.o 
+obj-m += rfnm_granita.o 
 
 obj-m += rfnm_lime.o rfnm_breakout.o
 

--- a/kernel_driver/la9310rfnm/rfnm_usb.c
+++ b/kernel_driver/la9310rfnm/rfnm_usb.c
@@ -32,8 +32,16 @@
 
 #include "drivers/usb/gadget/function/f_mass_storage.h"
 
+/* USB functions for functionMask parameter, RFNM function is always enabled*/
+#define FN_MSG 1
+#define FN_NCM 2
+
+
 /*-------------------------------------------------------------------------*/
 USB_GADGET_COMPOSITE_OPTIONS();
+
+static int functionMask = FN_MSG | FN_NCM; // Default, all functions
+module_param(functionMask, int, S_IRUSR | S_IRGRP | S_IROTH);
 
 static struct usb_device_descriptor rfnm_device_desc = {
 	.bLength =		sizeof rfnm_device_desc,
@@ -126,7 +134,9 @@ static int rfnm_do_config(struct usb_configuration *c)
 	c->cdev->os_desc_config = &os_desc_config;
 #endif
 	printk("Sending os driver data from callback\n");
+	printk("FunctionMask = %X\n", functionMask);
 
+	
 	f_rfnm = usb_get_function(fi_rfnm);
 	if (IS_ERR(f_rfnm))
 		return PTR_ERR(f_rfnm);
@@ -136,26 +146,29 @@ static int rfnm_do_config(struct usb_configuration *c)
 		goto put_func;
 
 	os_desc_config.interface[0] = f_rfnm;
+	
 
-#if 1
+	if (functionMask & FN_MSG)
+	{
+		f_msg = usb_get_function(fi_msg);
+		if (IS_ERR(f_msg))
+			return PTR_ERR(f_msg);
 
-	f_msg = usb_get_function(fi_msg);
-	if (IS_ERR(f_msg))
-		return PTR_ERR(f_msg);
+		ret = usb_add_function(c, f_msg);
+		if (ret)
+			goto put_func;
+	}
 
-	ret = usb_add_function(c, f_msg);
-	if (ret)
-		goto put_func;
-#endif
+	if (functionMask & FN_NCM)
+	{
+		f_ncm = usb_get_function(fi_ncm);
+		if (IS_ERR(f_ncm))
+			return PTR_ERR(f_ncm);
 
-
-	f_ncm = usb_get_function(fi_ncm);
-	if (IS_ERR(f_ncm))
-		return PTR_ERR(f_ncm);
-
-	ret = usb_add_function(c, f_ncm);
-	if (ret)
-		goto put_func;
+		ret = usb_add_function(c, f_ncm);
+		if (ret)
+			goto put_func;
+	}	
 
 	printk("callback ok\n");
 
@@ -242,33 +255,39 @@ static int rfnm_bind(struct usb_composite_dev *cdev)
 	if (IS_ERR(fi_rfnm))
 		return PTR_ERR(fi_rfnm);
 
-	fi_msg = usb_get_function_instance("mass_storage");
-	if (IS_ERR(fi_msg))
-		return PTR_ERR(fi_msg);
+	if (functionMask & FN_NCM)
+	{
+		fi_ncm = usb_get_function_instance("ncm");
+		if (IS_ERR(fi_ncm))
+			return PTR_ERR(fi_ncm);
+	}
 
-	fi_ncm = usb_get_function_instance("ncm");
-	if (IS_ERR(fi_ncm))
-		return PTR_ERR(fi_ncm);
+	if (functionMask & FN_MSG)
+	{
+		fi_msg = usb_get_function_instance("mass_storage");
+		if (IS_ERR(fi_msg))
+			return PTR_ERR(fi_msg);
 
-	fsg_config_from_params(&msg_config, &msg_mod_data, fsg_num_buffers);
-	msg_opts = fsg_opts_from_func_inst(fi_msg);
+		fsg_config_from_params(&msg_config, &msg_mod_data, fsg_num_buffers);
+		msg_opts = fsg_opts_from_func_inst(fi_msg);
 
-	msg_opts->no_configfs = true;
-	status = fsg_common_set_num_buffers(msg_opts->common, fsg_num_buffers);
-	if (status)
-		goto fail;
+		msg_opts->no_configfs = true;
+		status = fsg_common_set_num_buffers(msg_opts->common, fsg_num_buffers);
+		if (status)
+			goto fail;
 
-	status = fsg_common_set_cdev(msg_opts->common, cdev, msg_config.can_stall);
-	if (status)
-		goto fail;
+		status = fsg_common_set_cdev(msg_opts->common, cdev, msg_config.can_stall);
+		if (status)
+			goto fail;
 
-	fsg_common_set_sysfs(msg_opts->common, true);
-	status = fsg_common_create_luns(msg_opts->common, &msg_config);
-	if (status)
-		goto fail;
+		fsg_common_set_sysfs(msg_opts->common, true);
+		status = fsg_common_create_luns(msg_opts->common, &msg_config);
+		if (status)
+			goto fail;
 
-	fsg_common_set_inquiry_string(msg_opts->common, msg_config.vendor_name,
-				      msg_config.product_name);
+		fsg_common_set_inquiry_string(msg_opts->common, msg_config.vendor_name,
+						msg_config.product_name);
+	}
 
 	status = usb_string_ids_tab(cdev, strings_dev);
 	if (status < 0)

--- a/reload.sh
+++ b/reload.sh
@@ -1,0 +1,13 @@
+insmod kernel_driver/la9310rfnm/la9310rfnm.ko
+
+
+insmod kernel_driver/la9310rfnm/rfnm_lalib.ko
+insmod kernel_driver/la9310rfnm/rfnm_daughterboard.ko
+
+insmod kernel_driver/la9310rfnm/rfnm_usb_function.ko
+insmod kernel_driver/la9310rfnm/rfnm_usb.ko file=/rfnm/scripts/backing_storage
+insmod kernel_driver/la9310rfnm/rfnm_usb_boost.ko file=/rfnm/scripts/backing_storage_boost
+
+#insmod kernel_driver/la9310rfnm/rfnm_lime.ko
+#insmod kernel_driver/la9310rfnm/rfnm_granita.ko
+insmod kernel_driver/la9310rfnm/rfnm_breakout.ko

--- a/reload.sh
+++ b/reload.sh
@@ -5,8 +5,8 @@ insmod kernel_driver/la9310rfnm/rfnm_lalib.ko
 insmod kernel_driver/la9310rfnm/rfnm_daughterboard.ko
 
 insmod kernel_driver/la9310rfnm/rfnm_usb_function.ko
-insmod kernel_driver/la9310rfnm/rfnm_usb.ko file=/rfnm/scripts/backing_storage
-insmod kernel_driver/la9310rfnm/rfnm_usb_boost.ko file=/rfnm/scripts/backing_storage_boost
+insmod kernel_driver/la9310rfnm/rfnm_usb.ko file=/rfnm/scripts/backing_storage functionMask=0
+#insmod kernel_driver/la9310rfnm/rfnm_usb_boost.ko file=/rfnm/scripts/backing_storage_boost
 
 #insmod kernel_driver/la9310rfnm/rfnm_lime.ko
 #insmod kernel_driver/la9310rfnm/rfnm_granita.ko

--- a/unload.sh
+++ b/unload.sh
@@ -1,0 +1,9 @@
+rmmod rfnm_breakout
+rmmod rfnm_granita
+rmmod rfnm_lime
+rmmod rfnm_usb_boost
+rmmod rfnm_usb
+rmmod rfnm_usb_function
+rmmod rfnm_daughterboard
+rmmod rfnm_lalib
+rmmod la9310rfnm


### PR DESCRIPTION
Updated rfnm_usb driver to support functionMask parameter
	• Default all functions enabled
	• 0x01 = Enable Mass Storage
	• 0x02 = Enable NCM
        • 0x03 = Enable both


Additionally, remove hard path in Makefile and update README to reflect RFNM build





