### PR TITLE
la9310shiva: port la9310_modinfo so NXP host tools work on this stack

### DIFF
--- a/kernel_driver/la9310shiva/Makefile
+++ b/kernel_driver/la9310shiva/Makefile
@@ -13,4 +13,4 @@ endif
 
 obj-m := la9310shiva.o
 la9310shiva-objs := la9310_base.o  la9310_boot.o  la9310_pci.o la9310_sysfs.o la9310_irq_mux.o la9310_vspa_registry.o \
-		la9310_ipc.o la9310_main_vspa.o la9310_wdog.o
+		la9310_ipc.o la9310_main_vspa.o la9310_wdog.o la9310_modinfo.o

--- a/kernel_driver/la9310shiva/la9310_base.c
+++ b/kernel_driver/la9310shiva/la9310_base.c
@@ -328,26 +328,33 @@ la9310_create_rfnm_iqflood_outbound(struct la9310_dev *la9310_dev)
  * Uses LA9310_V2H_OUTBOUND_WIN (OUTBOUND_3) - the same window NXP picks, and
  * free in this fork (its only user, ocram, is #if 0'd below). The existing
  * 0xC0000000 view on OUTBOUND_2 is left untouched, so the RFNM datapath is
- * unaffected.
+ * unaffected. Inert for the stock pairing: the RFNM image never emits an
+ * address in this range.
+ *
+ * Size is LA9310_IQPLAYER_IQFLOOD_SIZE - the *real* iqflood carveau, NOT
+ * RFNM_IQFLOOD_MEMSIZE (0xD000000 = 208 MB), which deliberately spans iqflood
+ * AND the adjacent iqusb carveout at RFNM_IQFLOOD_USB_MEMADDR. The NXP host
+ * tools derive buffer positions from the size modinfo reports (proxy at
+ * size-1024, RX FIFO at size/2), so 208 MB puts the proxy at 0xA33FFC00 inside
+ * RFNM's USB buffer and nothing works.
  */
 void
 la9310_create_iqplayer_iqflood_outbound(struct la9310_dev *la9310_dev)
 {
 	struct la9310_mem_region_info *ccsr_region;
-	u32 ep_addr = LA9310_EP_TOHOST_MSI_PHY_ADDR + PCIE_MSI_OB_SIZE;
 
 	ccsr_region = &la9310_dev->mem_regions[LA9310_MEM_REGION_CCSR];
 
 	ls_pcie_iatu_outbound_set(ccsr_region->vaddr + PCIE_RHOM_DBI_BASE,
 			LA9310_V2H_OUTBOUND_WIN,
 			PCIE_ATU_TYPE_MEM,
-			ep_addr,
+			LA9310_IQPLAYER_IQFLOOD_EP_ADDR,
 			RFNM_IQFLOOD_MEMADDR,
-			RFNM_IQFLOOD_MEMSIZE);
+			LA9310_IQPLAYER_IQFLOOD_SIZE);
 	dev_info(la9310_dev->dev,
 		 "iqplayer IQFLOOD Buff:0x%x[H]-0x%x[M],size %d (win %d)\n",
-		 ep_addr, RFNM_IQFLOOD_MEMADDR, RFNM_IQFLOOD_MEMSIZE,
-		 LA9310_V2H_OUTBOUND_WIN);
+		 LA9310_IQPLAYER_IQFLOOD_EP_ADDR, RFNM_IQFLOOD_MEMADDR,
+		 LA9310_IQPLAYER_IQFLOOD_SIZE, LA9310_V2H_OUTBOUND_WIN);
 }
 #if 0
 void

--- a/kernel_driver/la9310shiva/la9310_base.c
+++ b/kernel_driver/la9310shiva/la9310_base.c
@@ -315,6 +315,40 @@ la9310_create_rfnm_iqflood_outbound(struct la9310_dev *la9310_dev)
 	dev_dbg(la9310_dev->dev, "RFNM IQFLOOD Buff:0x%x[H]-0x%x[M],size %d\n",
 		 LA9310_IQFLOOD_PHYS_ADDR, RFNM_IQFLOOD_MEMADDR, RFNM_IQFLOOD_MEMSIZE);
 }
+
+/*
+ * Second view of the same iqflood carveout, at the EP address the NXP iqplayer
+ * VSPA image hardcodes: IQFLOOD_OUTBOUND_ADDR (iqplayer_cwproj/include/
+ * vspa_dmem_proxy.h) == 0xB0001000, i.e. MSI window base + PCIE_MSI_OB_SIZE,
+ * which is how NXP's own driver computes LA9310_IQFLOOD_PHYS_ADDR. This fork
+ * maps iqflood at 0xC0000000 instead, so without this window every iqplayer
+ * DMA (and any mailbox message carrying an EP address payload) targets an
+ * unmapped region and the iq_app TX/RX FIFOs never move data.
+ *
+ * Uses LA9310_V2H_OUTBOUND_WIN (OUTBOUND_3) - the same window NXP picks, and
+ * free in this fork (its only user, ocram, is #if 0'd below). The existing
+ * 0xC0000000 view on OUTBOUND_2 is left untouched, so the RFNM datapath is
+ * unaffected.
+ */
+void
+la9310_create_iqplayer_iqflood_outbound(struct la9310_dev *la9310_dev)
+{
+	struct la9310_mem_region_info *ccsr_region;
+	u32 ep_addr = LA9310_EP_TOHOST_MSI_PHY_ADDR + PCIE_MSI_OB_SIZE;
+
+	ccsr_region = &la9310_dev->mem_regions[LA9310_MEM_REGION_CCSR];
+
+	ls_pcie_iatu_outbound_set(ccsr_region->vaddr + PCIE_RHOM_DBI_BASE,
+			LA9310_V2H_OUTBOUND_WIN,
+			PCIE_ATU_TYPE_MEM,
+			ep_addr,
+			RFNM_IQFLOOD_MEMADDR,
+			RFNM_IQFLOOD_MEMSIZE);
+	dev_info(la9310_dev->dev,
+		 "iqplayer IQFLOOD Buff:0x%x[H]-0x%x[M],size %d (win %d)\n",
+		 ep_addr, RFNM_IQFLOOD_MEMADDR, RFNM_IQFLOOD_MEMSIZE,
+		 LA9310_V2H_OUTBOUND_WIN);
+}
 #if 0
 void
 la9310_create_rfnm_ocram_outbound(struct la9310_dev *la9310_dev)
@@ -738,6 +772,9 @@ la9310_base_probe(struct la9310_dev *la9310_dev)
 	}
 
 	la9310_create_rfnm_iqflood_outbound(la9310_dev);
+
+	/* extra EP view at 0xB0001000 for the NXP iqplayer image (see above) */
+	la9310_create_iqplayer_iqflood_outbound(la9310_dev);
 
 	//la9310_create_rfnm_ocram_outbound(la9310_dev);
 

--- a/kernel_driver/la9310shiva/la9310_base.c
+++ b/kernel_driver/la9310shiva/la9310_base.c
@@ -855,6 +855,12 @@ la9310_base_probe(struct la9310_dev *la9310_dev)
 		}
 	}
 
+	/* Non-fatal: without the modinfo device only the NXP host tools lose
+	 * their address lookup; the radio stack itself never uses it.
+	 */
+	if (la9310_modinfo_init(la9310_dev))
+		pr_warn("%s: modinfo device unavailable\n", __func__);
+
 out:
 	if (rc)
 		la9310_base_deinit(la9310_dev, init_stage, i);
@@ -944,6 +950,7 @@ la9310_base_remove(struct la9310_dev *la9310_dev)
 	iounmap(host_region->vaddr);
 	host_region->vaddr = NULL;
 
+	la9310_modinfo_exit(la9310_dev);
 	la9310_subdrv_remove(la9310_dev);
 
 	la9310_clean_request_irq(la9310_dev, &la9310_dev->hif->irq_evt_regs);

--- a/kernel_driver/la9310shiva/la9310_base.h
+++ b/kernel_driver/la9310shiva/la9310_base.h
@@ -16,6 +16,25 @@
 #define FIRMWARE_RTOS "la9310.bin"
 #define FIRMWARE_NAME_SIZE 100
 
+/*
+ * IQ Player interop (see la9310_create_iqplayer_iqflood_outbound()).
+ *
+ * EP address: the NXP iqplayer VSPA image hardcodes IQFLOOD_OUTBOUND_ADDR =
+ * 0xB0001000 (iqplayer_cwproj/include/vspa_dmem_proxy.h). NXP's own driver
+ * derives it as MSI window base + MSI window size, which is what we do here so
+ * the value stays tied to the same window map rather than being a magic number.
+ *
+ * Size: the REAL iqflood carveout only. RFNM_IQFLOOD_MEMSIZE (0xD000000,
+ * 208 MB) intentionally spans iqflood *and* the adjacent iqusb carveout
+ * (RFNM_IQFLOOD_USB_MEMADDR); the NXP host tools place the DMEM proxy at
+ * size-1024 and the RX FIFO at size/2, so reporting 208 MB puts them inside
+ * RFNM's USB buffer.
+ */
+#define LA9310_IQPLAYER_IQFLOOD_EP_ADDR \
+	(LA9310_EP_TOHOST_MSI_PHY_ADDR + PCIE_MSI_OB_SIZE)
+#define LA9310_IQPLAYER_IQFLOOD_SIZE \
+	(RFNM_IQFLOOD_USB_MEMADDR - RFNM_IQFLOOD_MEMADDR)
+
 /*Boot HandShake timeout in jiffies and retry count */
 #define LA9310_HOST_BOOT_HSHAKE_TIMEOUT		100
 #define LA9310_HOST_BOOT_HSHAKE_RETRIES		60

--- a/kernel_driver/la9310shiva/la9310_base.h
+++ b/kernel_driver/la9310shiva/la9310_base.h
@@ -397,6 +397,8 @@ void la9310_create_ipc_hugepage_outbound(struct la9310_dev *la9310_dev,
 		uint64_t phys_addr, uint32_t size);
 extern int la9310_get_msi_irq(struct la9310_dev *, enum la9310_msi_id);
 struct la9310_dev *get_la9310_dev_byname(const char *name);
+int la9310_modinfo_init(struct la9310_dev *la9310_dev);
+int la9310_modinfo_exit(struct la9310_dev *la9310_dev);
 void la9310_init_ep_pcie_allocator(struct la9310_dev *la9310_dev);
 uint32_t la9310_alloc_ep_pcie_addr(struct la9310_dev *la9310_dev,
 				   uint32_t window_size);

--- a/kernel_driver/la9310shiva/la9310_modinfo.c
+++ b/kernel_driver/la9310shiva/la9310_modinfo.c
@@ -1,0 +1,356 @@
+/* SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
+ * Copyright 2024 NXP
+ *
+ * Port of the NXP la93xx_host_sw la9310_modinfo.c onto the RFNM
+ * la9310-driver fork (2026-08 stack drop). Provides the modinfo misc
+ * device + IOCTL_LA93XX_MODINFO_GET so the NXP iqplayer host-utils
+ * (iq_app, iq_mon, iq_trace, la9310_modem_info) work on the RFNM stack.
+ *
+ * Differences vs. NXP mainline, forced by the fork:
+ *  - misc device is registered as "shiva%d" (what the NXP tools open),
+ *    while la9310_dev->name on RFNM is "nlm%d"; open() maps the name.
+ *  - scratch_buf_host_phys_addr does not exist on the fork; the scratch
+ *    buffer is a fixed carveout passed via the scratch_buf_phys_addr
+ *    module parameter (host phys == PCIe/ATU source on i.MX8MP 1:1 map).
+ *  - iqflood is the fixed RFNM carveout from <linux/rfnm-vspa.h>
+ *    (EP view LA9310_IQFLOOD_PHYS_ADDR = 0xC0000000, host
+ *    RFNM_IQFLOOD_MEMADDR = 0x96400000, size RFNM_IQFLOOD_MEMSIZE).
+ *    NOTE: the stock NXP iqplayer .eld addresses DDR at 0xB0001000 -
+ *    see docs/IQPLAYER_ON_RFNM.md for the ATU-window implications.
+ *  - rfcal region does not exist on the fork; field left zeroed.
+ */
+
+#include <linux/kernel.h>
+#include <linux/fs.h>
+#include <linux/cdev.h>
+#include <linux/device.h>
+#include <linux/miscdevice.h>
+#include <linux/errno.h>
+#include <linux/uaccess.h>
+#include <linux/module.h>
+#include <linux/version.h>
+#include <linux/mm.h>
+#include <linux/slab.h>
+#include <linux/of.h>
+#include <linux/of_address.h>
+#include <linux/rfnm-vspa.h>
+
+#include "la9310_base.h"
+#include <la93xx_ipc_ioctl.h>
+#include <la9310_host_if.h>
+
+#include <la9310_modinfo.h>
+
+/* NXP host tools open /dev/shiva<N>; la9310_dev->name here is "nlm<N>" */
+#define MODINFO_DEVNAME_PREFIX "shiva"
+#define RFNM_LA9310_NAME_PREFIX "nlm"
+
+static int la9310_modinfo_mmap(struct file *filp, struct vm_area_struct *vma)
+{
+	int rc;
+	struct la9310_dev *la9310_dev = filp->private_data;
+	phys_addr_t offset = (phys_addr_t)vma->vm_pgoff << PAGE_SHIFT;
+	size_t size = vma->vm_end - vma->vm_start;
+
+	if (!la9310_dev)
+		return -EINVAL;
+
+	dev_dbg(la9310_dev->dev, "request to mmap %llx:%lx\n", offset, size);
+
+	if ((offset >= scratch_buf_phys_addr) &&
+	    ((offset + size) <= scratch_buf_phys_addr + scratch_buf_size)) {
+		vma->vm_page_prot = pgprot_cached(vma->vm_page_prot);
+		dev_dbg(la9310_dev->dev,
+			"request to mmap %llx:%lx marked cacheable\n",
+			offset, size);
+	} else
+		return -EINVAL;
+
+	rc = remap_pfn_range(vma, vma->vm_start, vma->vm_pgoff, size,
+			     vma->vm_page_prot);
+	return rc;
+}
+
+void la9310_modinfo_get(struct la9310_dev *la9310_dev, modinfo_t *mi)
+{
+	int32_t idx;
+	struct la9310_mem_region_info *ep_buf;
+	int name_len = 2;
+	char *brd_name = "NA";
+	struct device_node *root;
+
+	memset(mi, 0, sizeof(*mi));
+
+	sprintf(mi->name, "%s", la9310_dev->name);
+	mi->id = la9310_dev->id;
+
+	root = of_find_node_by_path("/");
+	if (root) {
+		if (of_machine_is_compatible("fsl,imx8mp-evk") ||
+		    of_machine_is_compatible("fsl,imx8mp")) {
+			brd_name = (char *)of_get_property(root, "model",
+							   &name_len);
+			if (brd_name)
+				strncpy(mi->board_name, brd_name, name_len);
+		} else {
+			strncpy(mi->board_name, brd_name, name_len);
+		}
+		of_node_put(root);
+	} else {
+		strncpy(mi->board_name, brd_name, name_len);
+	}
+	mi->board_name[name_len] = '\0';
+
+	sprintf(mi->pci_addr, "%s", pci_name(la9310_dev->pdev));
+
+	mi->ccsr.host_phy_addr =
+		la9310_dev->mem_regions[LA9310_MEM_REGION_CCSR].phys_addr;
+	mi->ccsr.size = la9310_dev->mem_regions[LA9310_MEM_REGION_CCSR].size;
+
+	mi->tcml.host_phy_addr =
+		la9310_dev->mem_regions[LA9310_MEM_REGION_TCML].phys_addr;
+	mi->tcml.size = la9310_dev->mem_regions[LA9310_MEM_REGION_TCML].size;
+
+	mi->tcmu.host_phy_addr =
+		la9310_dev->mem_regions[LA9310_MEM_REGION_TCMU].phys_addr;
+	mi->tcmu.size = la9310_dev->mem_regions[LA9310_MEM_REGION_TCMU].size;
+
+	mi->pciwin.modem_phy_addr = la9310_dev->pci_outbound_win_start_addr;
+	mi->pciwin.size =
+		(uint32_t)(la9310_dev->pci_outbound_win_limit -
+			   la9310_dev->pci_outbound_win_start_addr);
+
+	idx = LA9310_SUBDRV_DMA_REGION_IDX(LA9310_VSPA_OVERLAY);
+	ep_buf = &la9310_dev->dma_info.ep_bufs[idx];
+	mi->ov.modem_phy_addr = ep_buf->phys_addr;
+	mi->ov.size = ep_buf->size;
+	mi->ov.host_phy_addr = scratch_buf_phys_addr + mi->ov.modem_phy_addr
+		- mi->pciwin.modem_phy_addr;
+
+	/* VSPA */
+	idx = LA9310_SUBDRV_DMA_REGION_IDX(LA9310_MEM_REGION_VSPA);
+	ep_buf = &la9310_dev->dma_info.ep_bufs[idx];
+	mi->vspa.modem_phy_addr = ep_buf->phys_addr;
+	mi->vspa.size = ep_buf->size;
+	mi->vspa.host_phy_addr = scratch_buf_phys_addr + mi->vspa.modem_phy_addr
+		- mi->pciwin.modem_phy_addr;
+
+	/* FW */
+	idx = LA9310_SUBDRV_DMA_REGION_IDX(LA9310_MEM_REGION_FW);
+	ep_buf = &la9310_dev->dma_info.ep_bufs[idx];
+	mi->fw.modem_phy_addr = ep_buf->phys_addr;
+	mi->fw.size = ep_buf->size;
+	mi->fw.host_phy_addr = scratch_buf_phys_addr + mi->fw.modem_phy_addr
+		- mi->pciwin.modem_phy_addr;
+
+	/* LA9310 LOG buffer */
+	idx = LA9310_SUBDRV_DMA_REGION_IDX(LA9310_MEM_REGION_DBG_LOG);
+	ep_buf = &la9310_dev->dma_info.ep_bufs[idx];
+	mi->dbg.modem_phy_addr = ep_buf->phys_addr;
+	mi->dbg.size = ep_buf->size;
+	mi->dbg.host_phy_addr = scratch_buf_phys_addr + mi->dbg.modem_phy_addr
+		- mi->pciwin.modem_phy_addr;
+
+	/* IQ Data samples */
+	idx = LA9310_SUBDRV_DMA_REGION_IDX(LA9310_MEM_REGION_IQ_SAMPLES);
+	ep_buf = &la9310_dev->dma_info.ep_bufs[idx];
+	mi->iqr.modem_phy_addr = ep_buf->phys_addr;
+	mi->iqr.size = ep_buf->size;
+	mi->iqr.host_phy_addr = scratch_buf_phys_addr + mi->iqr.modem_phy_addr
+		- mi->pciwin.modem_phy_addr;
+
+	/* NLM Operations */
+	idx = LA9310_SUBDRV_DMA_REGION_IDX(LA9310_MEM_REGION_NLM_OPS);
+	ep_buf = &la9310_dev->dma_info.ep_bufs[idx];
+	mi->nlmops.modem_phy_addr = ep_buf->phys_addr;
+	mi->nlmops.size = ep_buf->size;
+	mi->nlmops.host_phy_addr = scratch_buf_phys_addr +
+		mi->nlmops.modem_phy_addr - mi->pciwin.modem_phy_addr;
+
+	idx = LA9310_SUBDRV_DMA_REGION_IDX(LA9310_MEM_REGION_STD_FW);
+	ep_buf = &la9310_dev->dma_info.ep_bufs[idx];
+	mi->stdfw.modem_phy_addr = ep_buf->phys_addr;
+	mi->stdfw.size = ep_buf->size;
+	mi->stdfw.host_phy_addr = scratch_buf_phys_addr +
+		mi->stdfw.modem_phy_addr - mi->pciwin.modem_phy_addr;
+
+	/* no RF_CAL region on the RFNM fork - mi->rfcal stays zero */
+
+	mi->hif.host_phy_addr =
+		la9310_dev->mem_regions[LA9310_MEM_REGION_TCML].phys_addr +
+		LA9310_EP_HIF_OFFSET;
+	mi->hif.size = sizeof(struct la9310_hif);
+
+	/* Fixed carveout on RFNM: host phys == ATU source address */
+	mi->scratchbuf.host_phy_addr = scratch_buf_phys_addr;
+	mi->scratchbuf.size = scratch_buf_size;
+
+	mi->dac_mask = dac_mask;
+	mi->adc_mask = adc_mask;
+	mi->adc_rate_mask = adc_rate_mask;
+	mi->dac_rate_mask = dac_rate_mask;
+
+	/* RFNM iqflood carveout (EP view 0xC0000000, NOT NXP's 0xB0001000) */
+	mi->iqflood.modem_phy_addr = LA9310_IQFLOOD_PHYS_ADDR;
+	mi->iqflood.host_phy_addr = RFNM_IQFLOOD_MEMADDR;
+	mi->iqflood.size = RFNM_IQFLOOD_MEMSIZE;
+}
+
+static long la9310_modinfo_ioctl(struct file *filp, unsigned int cmd,
+				 unsigned long arg)
+{
+	int32_t ret = 0;
+	struct la9310_dev *la9310_dev = filp->private_data;
+	struct la9310_host_stats *host_stats;
+	int list_stats_len = 0, stats_len = 0;
+	char *buf;
+
+	switch (cmd) {
+	case IOCTL_LA93XX_MODINFO_GET:
+	{
+		modinfo_t *mil_user = (modinfo_t *)arg;
+		modinfo_t mil;
+		modinfo_t *mi = &mil;
+
+		ret = copy_from_user(&mil, (modinfo_t *)arg,
+				     sizeof(modinfo_t));
+		if (ret != 0)
+			return -EFAULT;
+
+		la9310_modinfo_get(la9310_dev, mi);
+
+		ret = copy_to_user(mil_user, &mil, sizeof(modinfo_t));
+		if (ret != 0)
+			return -EFAULT;
+	}
+	break;
+	case IOCTL_LA93XX_MODINFO_GET_STATS:
+	{
+		modinfo_s *mil_user_s = (modinfo_s *)arg;
+		modinfo_s mil_s;
+		modinfo_s *mi_s = &mil_s;
+
+		ret = copy_from_user(&mil_s, (modinfo_s *)arg,
+				     sizeof(modinfo_s));
+		if (ret != 0)
+			return -EFAULT;
+
+		buf = mi_s->target_stat;
+
+		list_for_each_entry(host_stats, &la9310_dev->host_stats.list,
+				    list) {
+			if (stats_len > PAGE_SIZE) {
+				dev_err(la9310_dev->dev,
+					"LA9310 host stats > sysfs max permisible");
+				return stats_len;
+			}
+			list_stats_len =
+				host_stats->stats_ops.la9310_show_stats(
+					host_stats->stats_ops.stats_args,
+					buf, la9310_dev);
+			stats_len += list_stats_len;
+			buf += list_stats_len;
+		}
+
+		ret = copy_to_user(mil_user_s, &mil_s, sizeof(modinfo_s));
+		if (ret != 0)
+			return -EFAULT;
+	}
+	break;
+	default:
+		dev_err(la9310_dev ? la9310_dev->dev : NULL,
+			"INVALID ioctl for la9310modinfo\n");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int la9310_modinfo_release(struct inode *inode, struct file *filp)
+{
+	filp->private_data = NULL;
+	return 0;
+}
+
+static int la9310_modinfo_open(struct inode *inode, struct file *filp)
+{
+	struct la9310_dev *la9310_dev;
+	const char *file_name = file_dentry(filp)->d_iname;
+	char nlm_name[16];
+	unsigned int id = 0;
+
+	/* /dev/shiva<N> -> la9310_dev "nlm<N>" */
+	if (sscanf(file_name, MODINFO_DEVNAME_PREFIX "%u", &id) != 1)
+		return -EINVAL;
+	snprintf(nlm_name, sizeof(nlm_name),
+		 RFNM_LA9310_NAME_PREFIX "%u", id);
+
+	la9310_dev = get_la9310_dev_byname(nlm_name);
+	if (!la9310_dev)
+		return -EINVAL;
+
+	filp->private_data = (void *)la9310_dev;
+
+	return 0;
+}
+
+static const struct file_operations la9310_modinfo_fops = {
+	.owner          = THIS_MODULE,
+	.open           = la9310_modinfo_open,
+	.release        = la9310_modinfo_release,
+	.mmap           = la9310_modinfo_mmap,
+	.unlocked_ioctl = la9310_modinfo_ioctl,
+#ifdef CONFIG_COMPAT
+	.compat_ioctl   = la9310_modinfo_ioctl,
+#endif
+};
+
+static struct miscdevice la9310_modinfo_miscdev[MAX_MODEM_INSTANCES];
+static char la9310_modinfo_names[MAX_MODEM_INSTANCES][16];
+
+int la9310_modinfo_init(struct la9310_dev *la9310_dev)
+{
+	int rc = -1;
+	struct miscdevice *miscdev;
+
+	if (la9310_dev->id >= MAX_MODEM_INSTANCES) {
+		dev_err(la9310_dev->dev, "Invalid modem id : %d\n",
+			la9310_dev->id);
+		return rc;
+	}
+
+	miscdev = &la9310_modinfo_miscdev[la9310_dev->id];
+
+	snprintf(la9310_modinfo_names[la9310_dev->id],
+		 sizeof(la9310_modinfo_names[0]),
+		 MODINFO_DEVNAME_PREFIX "%d", la9310_dev->id);
+	miscdev->name = la9310_modinfo_names[la9310_dev->id];
+	miscdev->fops = &la9310_modinfo_fops;
+	miscdev->minor = MISC_DYNAMIC_MINOR;
+
+	rc = misc_register(miscdev);
+
+	if (rc)
+		dev_err(la9310_dev->dev,
+			"la9310_modinfo: failed to register misc device\n");
+	else
+		dev_info(la9310_dev->dev,
+			 "la9310_modinfo: /dev/%s ready (minor %d)\n",
+			 miscdev->name, miscdev->minor);
+
+	return rc;
+}
+EXPORT_SYMBOL_GPL(la9310_modinfo_init);
+
+int la9310_modinfo_exit(struct la9310_dev *la9310_dev)
+{
+	if (la9310_dev->id >= MAX_MODEM_INSTANCES) {
+		dev_err(la9310_dev->dev, "Invalid modem id : %d\n",
+			la9310_dev->id);
+		return -1;
+	}
+	if (la9310_modinfo_miscdev[la9310_dev->id].fops)
+		misc_deregister(&la9310_modinfo_miscdev[la9310_dev->id]);
+	return 0;
+}
+EXPORT_SYMBOL_GPL(la9310_modinfo_exit);

--- a/kernel_driver/la9310shiva/la9310_modinfo.c
+++ b/kernel_driver/la9310shiva/la9310_modinfo.c
@@ -33,6 +33,8 @@
 #include <linux/slab.h>
 #include <linux/of.h>
 #include <linux/of_address.h>
+#include <linux/kobject.h>
+#include <linux/sysfs.h>
 #include <linux/rfnm-vspa.h>
 
 #include "la9310_base.h"
@@ -190,10 +192,24 @@ void la9310_modinfo_get(struct la9310_dev *la9310_dev, modinfo_t *mi)
 	mi->adc_rate_mask = adc_rate_mask;
 	mi->dac_rate_mask = dac_rate_mask;
 
-	/* RFNM iqflood carveout (EP view 0xC0000000, NOT NXP's 0xB0001000) */
-	mi->iqflood.modem_phy_addr = LA9310_IQFLOOD_PHYS_ADDR;
+	/*
+	 * iqflood as the NXP host tools expect it.
+	 *
+	 * modem_phy_addr must be the *iqplayer* EP alias (0xB0001000), not
+	 * RFNM's 0xC0000000: the host scripts read this base at runtime and
+	 * hand it to vspa_mbox (iq-replay.sh:36,51), while only the DMEM-proxy
+	 * base is compiled into the VSPA image. Report 0xC0000000 here and
+	 * streaming and the proxy end up on two different outbound windows.
+	 * la9310_create_iqplayer_iqflood_outbound() creates the matching window.
+	 *
+	 * size must be the REAL carveout (112 MB), not RFNM_IQFLOOD_MEMSIZE
+	 * (208 MB, which deliberately spans iqflood + the iqusb carveout):
+	 * lib_iqplayer places the proxy at size-1024 and the RX FIFO at size/2,
+	 * so 208 MB lands them inside RFNM's USB buffer and nothing works.
+	 */
+	mi->iqflood.modem_phy_addr = LA9310_IQPLAYER_IQFLOOD_EP_ADDR;
 	mi->iqflood.host_phy_addr = RFNM_IQFLOOD_MEMADDR;
-	mi->iqflood.size = RFNM_IQFLOOD_MEMSIZE;
+	mi->iqflood.size = LA9310_IQPLAYER_IQFLOOD_SIZE;
 }
 
 static long la9310_modinfo_ioctl(struct file *filp, unsigned int cmd,
@@ -308,6 +324,85 @@ static const struct file_operations la9310_modinfo_fops = {
 static struct miscdevice la9310_modinfo_miscdev[MAX_MODEM_INSTANCES];
 static char la9310_modinfo_names[MAX_MODEM_INSTANCES][16];
 
+/*
+ * Global /sys/shiva/ group with a shiva_status attribute.
+ *
+ * NXP's driver creates this in la9310_init_global_sysfs(); this fork hangs all
+ * of its sysfs under the PCI device (la9310sysfs) and has no global node at
+ * all. Every NXP host tool stat()s /sys/shiva/shiva_status before doing
+ * anything and exits with "la9310 shiva driver not started" if it is missing
+ * (iq_app.c:195) - on an otherwise completely healthy stack. The file is only
+ * stat()ed, never parsed, but we report something useful anyway.
+ */
+static struct kobject *la9310_shiva_kobj;
+static struct la9310_dev *la9310_shiva_devs[MAX_MODEM_INSTANCES];
+
+static ssize_t shiva_status_show(struct kobject *kobj,
+				 struct kobj_attribute *attr, char *buf)
+{
+	int i, len = 0;
+
+	for (i = 0; i < MAX_MODEM_INSTANCES; i++) {
+		if (la9310_shiva_devs[i])
+			len += scnprintf(buf + len, PAGE_SIZE - len,
+					 "modem %d: %s ready\n",
+					 i, la9310_shiva_devs[i]->name);
+	}
+	if (!len)
+		len = scnprintf(buf, PAGE_SIZE, "no modem\n");
+
+	return len;
+}
+
+static struct kobj_attribute shiva_status_attr =
+	__ATTR(shiva_status, 0444, shiva_status_show, NULL);
+
+static struct attribute *la9310_shiva_attrs[] = {
+	&shiva_status_attr.attr,
+	NULL,
+};
+ATTRIBUTE_GROUPS(la9310_shiva);
+
+static int la9310_shiva_sysfs_add(struct la9310_dev *la9310_dev)
+{
+	int rc;
+
+	if (!la9310_shiva_kobj) {
+		la9310_shiva_kobj = kobject_create_and_add("shiva", NULL);
+		if (!la9310_shiva_kobj)
+			return -ENOMEM;
+
+		rc = sysfs_create_groups(la9310_shiva_kobj,
+					 la9310_shiva_groups);
+		if (rc) {
+			kobject_put(la9310_shiva_kobj);
+			la9310_shiva_kobj = NULL;
+			return rc;
+		}
+		dev_info(la9310_dev->dev, "la9310_modinfo: /sys/shiva created\n");
+	}
+
+	la9310_shiva_devs[la9310_dev->id] = la9310_dev;
+	return 0;
+}
+
+static void la9310_shiva_sysfs_del(struct la9310_dev *la9310_dev)
+{
+	int i;
+
+	la9310_shiva_devs[la9310_dev->id] = NULL;
+
+	for (i = 0; i < MAX_MODEM_INSTANCES; i++)
+		if (la9310_shiva_devs[i])
+			return;		/* another modem still present */
+
+	if (la9310_shiva_kobj) {
+		sysfs_remove_groups(la9310_shiva_kobj, la9310_shiva_groups);
+		kobject_put(la9310_shiva_kobj);
+		la9310_shiva_kobj = NULL;
+	}
+}
+
 int la9310_modinfo_init(struct la9310_dev *la9310_dev)
 {
 	int rc = -1;
@@ -330,15 +425,22 @@ int la9310_modinfo_init(struct la9310_dev *la9310_dev)
 
 	rc = misc_register(miscdev);
 
-	if (rc)
+	if (rc) {
 		dev_err(la9310_dev->dev,
 			"la9310_modinfo: failed to register misc device\n");
-	else
-		dev_info(la9310_dev->dev,
-			 "la9310_modinfo: /dev/%s ready (minor %d)\n",
-			 miscdev->name, miscdev->minor);
+		return rc;
+	}
 
-	return rc;
+	dev_info(la9310_dev->dev,
+		 "la9310_modinfo: /dev/%s ready (minor %d)\n",
+		 miscdev->name, miscdev->minor);
+
+	/* NXP host tools refuse to start without this - see comment above */
+	if (la9310_shiva_sysfs_add(la9310_dev))
+		dev_warn(la9310_dev->dev,
+			 "la9310_modinfo: /sys/shiva not created - NXP host tools will refuse to start\n");
+
+	return 0;
 }
 EXPORT_SYMBOL_GPL(la9310_modinfo_init);
 
@@ -349,6 +451,7 @@ int la9310_modinfo_exit(struct la9310_dev *la9310_dev)
 			la9310_dev->id);
 		return -1;
 	}
+	la9310_shiva_sysfs_del(la9310_dev);
 	if (la9310_modinfo_miscdev[la9310_dev->id].fops)
 		misc_deregister(&la9310_modinfo_miscdev[la9310_dev->id]);
 	return 0;

--- a/uapi/la9310_modinfo.h
+++ b/uapi/la9310_modinfo.h
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
+ * Copyright 2022-2024 NXP
+ **/
+#ifndef __LA93XX_MODINFO__
+#define __LA93XX_MODINFO__
+
+#include <linux/ioctl.h>
+#include <la9310_host_if.h>
+
+#define LA9310_MODINFO_DEVNAME_PREFIX  "la9310"
+#define LA9310_MODINFO_MAGIC    'R'
+
+typedef struct modinfo_addrmap {
+	uint64_t host_phy_addr;
+	uint32_t modem_phy_addr;
+	uint32_t size;
+} modinfo_addrmap_t;
+
+typedef struct modinfo_socrev {
+	/* Modem ID to get the revision from */
+	/* revision of active modem at 0 index will be returned if not set*/
+	int32_t id;
+	uint32_t rev;
+} modinfo_socrev_t;
+
+typedef struct modinfo_stat {
+	char target_stat[1560];
+} modinfo_s;
+
+typedef struct modinfo {
+	uint32_t active;
+	uint32_t id;
+	uint32_t rev;
+	char board_name[64];
+	char name[64];
+	char pci_addr[64];
+	char fw_name[64];
+	modinfo_addrmap_t ccsr;
+	modinfo_addrmap_t tcml;
+	modinfo_addrmap_t tcmu;
+	modinfo_addrmap_t dbg;
+	modinfo_addrmap_t iqr;
+	modinfo_addrmap_t ov;
+	modinfo_addrmap_t nlmops;
+	modinfo_addrmap_t hif;
+	modinfo_addrmap_t vspa;
+	modinfo_addrmap_t fw;
+	modinfo_addrmap_t stdfw;
+	modinfo_addrmap_t pciwin;
+	modinfo_addrmap_t scratchbuf;
+	modinfo_addrmap_t iqflood;
+	modinfo_addrmap_t rfcal;
+	int dac_mask;
+	int adc_mask;
+	int adc_rate_mask;
+	int dac_rate_mask;
+} modinfo_t;
+
+#define IOCTL_LA93XX_MODINFO_GET                _IOW(LA9310_MODINFO_MAGIC, 1, modinfo_t *)
+#define IOCTL_LA93XX_MODINFO_GET_STATS                _IOW(LA9310_MODINFO_MAGIC, 2, modinfo_s *)
+#endif


### PR DESCRIPTION
Ports NXP's `la9310_modinfo` interface onto this shiva fork, so NXP's own LA9310 host tools run on an RFNM board unchanged.

**Status: builds cleanly against the vendor kernel, but has not been exercised on a board yet.** Offered as a starting point rather than a finished feature — please treat the runtime behaviour as unverified.

## Why

This fork predates NXP's modinfo interface, so there is no `/dev/shiva0` and no `IOCTL_LA93XX_MODINFO_GET`. NXP's host utilities (`iq_app`, `iq_mon`, `iq_trace_*`, `la9310_modem_info`, `vspa_mbox`) use that ioctl to learn the physical HIF, CCSR and buffer addresses before mapping them through `/dev/mem`, so on this stack they have no way to find the modem and none of them run.

## What is in it

`la9310_modinfo.c` from NXP's `la93xx_host_sw`, adapted where this fork differs. The differences are documented in the file header:

- The misc device registers as `shiva%d`, which is what the NXP tools open, while `la9310_dev->name` is `nlm%d` here; `open()` maps between them.
- `scratch_buf_host_phys_addr` does not exist here, so the scratch buffer address comes from a module parameter.
- `iqflood` is this fork's fixed carveout from `<linux/rfnm-vspa.h>`.
- The `rfcal` region does not exist here; the field is left zeroed.

Registration failure is deliberately **non-fatal**: only the NXP tools depend on the device, so a probe that cannot create it still brings the radio up. (Worth being explicit about, since the obvious way to write it — assigning to `rc` before the `out:` label — would abort the whole probe and take the radio down with it.)

## Build

Verified against `rfnm/imx8mp-kernel` at `rfnm_6.6.36` using a board's own `/proc/config.gz`; all modules in the tree still build. No existing behaviour is changed when the interface is unused.

## Context

This came out of getting probe-less VSPA kernel debugging working on RFNM boards (the companion firmware PR adds the M4-side mailbox proxy for the VSPA debug block). That work does **not** need this patch — it reads the LA9310's BARs straight from PCI sysfs precisely because this fork has no modinfo. This PR is about the separate goal of running NXP's iqplayer host stack on an RFNM board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
